### PR TITLE
fix: rc-tree-select版本更新时废弃了utils中的部分api,向下兼容问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "object-assign": "~4.1.0",
   "prop-types": "15.x",
   "rc-tree": "~1.7.1",
-  "rc-tree-select": "1.12.10",
+  "rc-tree-select": "~1.12.10",
   "rc-trigger": "^2.2.2",
   "rc-util": "^4.0.2"
  },

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -9,8 +9,8 @@ import assign from 'object-assign';
 import Animate from 'rc-animate';
 import {
   getPropValue, getValuePropValue, /* isCombobox,*/
-  isMultipleOrTags, isMultipleOrTagsOrCombobox,
-  isSingleMode, toArray,
+  // isMultipleOrTags, isMultipleOrTagsOrCombobox,
+  /* isSingleMode, */ toArray,
   UNSELECTABLE_ATTRIBUTE, UNSELECTABLE_STYLE,
   preventDefaultEvent,
   getTreeNodesStates, flatToHierarchy, filterParentPosition,
@@ -21,6 +21,7 @@ import SelectTrigger from './SelectTrigger';
 import TreeNode2 from 'rc-tree-select/lib/TreeNode';
 import { SHOW_ALL, SHOW_PARENT, SHOW_CHILD } from 'rc-tree-select/lib/strategies';
 import { SelectPropTypes } from 'rc-tree-select/lib//PropTypes';
+import { isMultipleOrTags, isMultipleOrTagsOrCombobox, isSingleMode} from './utils';
 
 function noop() {
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { isPositionPrefix, isInclude } from 'rc-tree-select/lib/util';
+import { isPositionPrefix, isInclude, isMultiple } from 'rc-tree-select/lib/util';
 
 // Refactor
 export function flatToHierarchy(arr, flag = false) {
@@ -49,4 +49,17 @@ export function flatToHierarchy(arr, flag = false) {
   // console.log(Date.now() - s);
   return levelObj[levelArr[levelArr.length - 1]].concat(hierarchyNodes);
 }
+
+export function isMultipleOrTags(props) {
+  return !!(isMultiple(props) || props.tags);
+}
+
+export function isMultipleOrTagsOrCombobox(props) {
+  return (isMultiple(props) || props.tags || props.combobox);
+}
+
+export function isSingleMode(props) {
+  return !(isMultiple(props) || props.tags || props.combobox);
+}
+
 


### PR DESCRIPTION
rc-tree-select版本废弃了部分api，提供的新api不能完全向下兼容，解决方案是在新的api上进行了扩展。